### PR TITLE
[feat] Generate OAS document for URLs with separate query parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /web/dist
 /web/node_modules
 /web/wasm
+
+tests/fixtures/*.oas.json

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ impl<'a> Transpiler<'a> {
                     let key = param.key.as_ref().map_or("", String::as_str);
                     let value = param.value.as_ref().map_or("", String::as_str);
 
-                    if value.is_empty() || key.is_empty() {
+                    if value.is_empty() {
                         None // Skip this parameter
                     } else {
                         Some(format!("{}={}", key, value))

--- a/tests/fixtures/wasm/openapi.json
+++ b/tests/fixtures/wasm/openapi.json
@@ -12,9 +12,11 @@
     }
   ],
   "paths": {
-    "/get": {
+    "/get/?foo1=bar1&foo2=bar2": {
       "get": {
-        "tags": ["Request Methods"],
+        "tags": [
+          "Request Methods"
+        ],
         "summary": "GET Request",
         "description": "The HTTP `GET` request method is meant to retrieve data from a server. The data\nis identified by a unique URI (Uniform Resource Identifier). \n\nA `GET` request can pass parameters to the server using \"Query String \nParameters\". For example, in the following request,\n\n> http://example.com/hi/there?hand=wave\n\nThe parameter \"hand\" has the value \"wave\".\n\nThis endpoint echoes the HTTP headers, request parameters and the complete\nURI requested.",
         "operationId": "getRequest",
@@ -179,7 +181,9 @@
     },
     "/post": {
       "post": {
-        "tags": ["Request Methods"],
+        "tags": [
+          "Request Methods"
+        ],
         "summary": "POST Raw Text",
         "description": "The HTTP `POST` request method is meant to transfer data to a server \n(and elicit a response). What data is returned depends on the implementation\nof the server.\n\nA `POST` request can pass parameters to the server using \"Query String \nParameters\", as well as the Request Body. For example, in the following request,\n\n> POST /hi/there?hand=wave\n>\n> <request-body>\n\nThe parameter \"hand\" has the value \"wave\". The request body can be in multiple\nformats. These formats are defined by the MIME type of the request. The MIME \nType can be set using the ``Content-Type`` HTTP header. The most commonly used \nMIME types are:\n\n* `multipart/form-data`\n* `application/x-www-form-urlencoded`\n* `application/json`\n\nThis endpoint echoes the HTTP headers, request parameters, the contents of\nthe request body and the complete URI requested.",
         "operationId": "postRawText",
@@ -226,7 +230,9 @@
     },
     "/put": {
       "put": {
-        "tags": ["Custom"],
+        "tags": [
+          "Custom"
+        ],
         "summary": "PUT Request",
         "description": "The HTTP `PUT` request method is similar to HTTP `POST`. It too is meant to \ntransfer data to a server (and elicit a response). What data is returned depends on the implementation\nof the server.\n\nA `PUT` request can pass parameters to the server using \"Query String \nParameters\", as well as the Request Body. For example, in the following \nraw HTTP request,\n\n> PUT /hi/there?hand=wave\n>\n> <request-body>\n\n\n",
         "operationId": "putRequest",
@@ -396,7 +402,9 @@
     },
     "/patch": {
       "patch": {
-        "tags": ["Request Methods"],
+        "tags": [
+          "Request Methods"
+        ],
         "summary": "PATCH Request",
         "description": "The HTTP `PATCH` method is used to update resources on a server. The exact\nuse of `PATCH` requests depends on the server in question. There are a number\nof server implementations which handle `PATCH` differently. Technically, \n`PATCH` supports both Query String parameters and a Request Body.\n\nThis endpoint accepts an HTTP `PATCH` request and provides debug information\nsuch as the HTTP headers, Query String arguments, and the Request Body.",
         "operationId": "patchRequest",
@@ -420,7 +428,9 @@
     },
     "/delete": {
       "delete": {
-        "tags": ["Request Methods"],
+        "tags": [
+          "Request Methods"
+        ],
         "summary": "DELETE Request",
         "description": "The HTTP `DELETE` method is used to delete resources on a server. The exact\nuse of `DELETE` requests depends on the server implementation. In general, \n`DELETE` requests support both, Query String parameters as well as a Request \nBody.\n\nThis endpoint accepts an HTTP `DELETE` request and provides debug information\nsuch as the HTTP headers, Query String arguments, and the Request Body.",
         "operationId": "deleteRequest",
@@ -444,7 +454,9 @@
     },
     "/headers": {
       "get": {
-        "tags": ["Headers"],
+        "tags": [
+          "Headers"
+        ],
         "summary": "Request Headers",
         "description": "A `GET` request to this endpoint returns the list of all request headers as part of the response JSON.\nIn Postman, sending your own set of headers through the [Headers tab](https://www.getpostman.com/docs/requests#headers?source=echo-collection-app-onboarding) will reveal the headers as part of the response.",
         "operationId": "requestHeaders",
@@ -582,9 +594,11 @@
         }
       }
     },
-    "/response-headers": {
+    "/response-headers/?foo1=bar1&foo2=bar2": {
       "get": {
-        "tags": ["Headers"],
+        "tags": [
+          "Headers"
+        ],
         "summary": "Response Headers",
         "description": "This endpoint causes the server to send custom set of response headers. Providing header values as part of the URL parameters of a `GET` request to this endpoint returns the same as part of response header.\n\nTo send your own set of headers, simply add or replace the the URL parameters with your own set.",
         "operationId": "responseHeaders",
@@ -690,7 +704,9 @@
     },
     "/basic-auth": {
       "get": {
-        "tags": ["Authentication Methods"],
+        "tags": [
+          "Authentication Methods"
+        ],
         "summary": "Basic Auth",
         "description": "This endpoint simulates a **basic-auth** protected endpoint. \nThe endpoint accepts a default username and password and returns a status code of `200 ok` only if the same is provided. \nOtherwise it will return a status code `401 unauthorized`.\n\n> Username: `postman`\n> \n> Password: `password`\n\nTo use this endpoint, send a request with the header `Authorization: Basic cG9zdG1hbjpwYXNzd29yZA==`. \nThe cryptic latter half of the header value is a base64 encoded concatenation of the default username and password. \nUsing Postman, to send this request, you can simply fill in the username and password in the \"Authorization\" tab and Postman will do the rest for you.\n\nTo know more about basic authentication, refer to the [Basic Access Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) wikipedia article.\nThe article on [authentication helpers](https://www.getpostman.com/docs/helpers#basic-auth?source=echo-collection-app-onboarding) elaborates how to use the same within the Postman app.",
         "operationId": "basicAuth",
@@ -772,7 +788,9 @@
     },
     "/digest-auth": {
       "get": {
-        "tags": ["Auth: Digest"],
+        "tags": [
+          "Auth: Digest"
+        ],
         "summary": "DigestAuth Success",
         "description": "This endpoint sends a hashed Digest Authorization header to gain access to a valid `200 Ok` response code. In Postman, it uses the stored [global variables](https://www.getpostman.com/docs/environments#gloval-variables?source=echo-collection-app-onboarding), `echo_digest_realm` and `echo_digest_nonce`, to generate the hashed authorisation header.\n\nWithin Postman, for this request to successfully authenticate, running the previous request \"DigestAuth Request\" stores the relevant information within the global variables.",
         "operationId": "digestauthSuccess",
@@ -854,7 +872,9 @@
     },
     "/auth/hawk": {
       "get": {
-        "tags": ["Authentication Methods"],
+        "tags": [
+          "Authentication Methods"
+        ],
         "summary": "Hawk Auth",
         "description": "This endpoint is a Hawk Authentication protected endpoint. [Hawk authentication](https://github.com/hueniverse/hawk) is a widely used protocol for protecting API endpoints. One of Hawk's main goals is to enable HTTP authentication for services that do not use TLS (although it can be used in conjunction with TLS as well).\n\nIn order to use this endpoint, select the \"Hawk Auth\" helper inside Postman, and set the following values:\n\nHawk Auth ID: `dh37fgj492je`\n\nHawk Auth Key: `werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn`\n\nAlgorithm: `sha256`\n\nThe rest of the values are optional, and can be left blank. Hitting send should give you a response with a status code of 200 OK.",
         "operationId": "hawkAuth",
@@ -942,7 +962,9 @@
     },
     "/oauth1": {
       "get": {
-        "tags": ["Authentication Methods"],
+        "tags": [
+          "Authentication Methods"
+        ],
         "summary": "OAuth1.0 (verify signature)",
         "description": "OAuth1.0a is a specification that defines a protocol that can be used by one\nservice to access \"protected\" resources (endpoints) on another service. A\nmajor part of OAuth1.0 is HTTP Request Signing. This endpoint allows you to \ncheck whether the request calculation works properly in the client. \n\nThe endpoint supports the HTTP ``Authorization`` header. In case the signature\nverification fails, the endpoint provides the four debug values,\n\n* ``base_uri``\n* ``normalized_param_string``\n* ``base_string``\n* ``signing_key``\n\nFor more details about these parameters, check the [OAuth1.0a Specification](http://oauth.net/core/1.0a/)\n\nIn order to use this endpoint, you can set the following values:\n\n> Consumer Key: ``RKCGzna7bv9YD57c``\n>\n> Consumer Secret: ``D+EdQ-gs$-%@2Nu7``\n\nIf you are using Postman, also check the \"Add params to header\" and \n\"Auto add parameters\" boxes.",
         "operationId": "oauth10VerifySignature",
@@ -1108,9 +1130,11 @@
         }
       }
     },
-    "/cookies/set": {
+    "/cookies/set/?foo1=bar1&foo2=bar2": {
       "get": {
-        "tags": ["Cookie Manipulation"],
+        "tags": [
+          "Cookie Manipulation"
+        ],
         "summary": "Set Cookies",
         "description": "The cookie setter endpoint accepts a list of cookies and their values as part of URL parameters of a `GET` request. These cookies are saved and can be subsequently retrieved or deleted. The response of this request returns a JSON with all cookies listed.\n\nTo set your own set of cookies, simply replace the URL parameters \"foo1=bar1&foo2=bar2\" with your own set of key-value pairs.",
         "operationId": "setCookies",
@@ -1217,7 +1241,9 @@
     },
     "/cookies": {
       "get": {
-        "tags": ["Cookie Manipulation"],
+        "tags": [
+          "Cookie Manipulation"
+        ],
         "summary": "Get Cookies",
         "description": "Use this endpoint to get a list of all cookies that are stored with respect to this domain. Whatever key-value pairs that has been previously set by calling the \"Set Cookies\" endpoint, will be returned as response JSON.",
         "operationId": "getCookies",
@@ -1301,7 +1327,9 @@
     },
     "/cookies/delete": {
       "get": {
-        "tags": ["Cookie Manipulation"],
+        "tags": [
+          "Cookie Manipulation"
+        ],
         "summary": "Delete Cookies",
         "description": "One or more cookies that has been set for this domain can be deleted by providing the cookie names as part of the URL parameter. The response of this request is a JSON containing the list of currently set cookies.",
         "operationId": "deleteCookies",
@@ -1401,7 +1429,9 @@
     },
     "/status/200": {
       "get": {
-        "tags": ["Utilities"],
+        "tags": [
+          "Utilities"
+        ],
         "summary": "Response Status Code",
         "description": "This endpoint allows one to instruct the server which status code to respond with.\n\nEvery response is accompanied by a status code. The status code provides a summary of the nature of response sent by the server. For example, a status code of `200` means everything is okay with the response and a code of `404` implies that the requested URL does not exist on server. \nA list of all valid HTTP status code can be found at the [List of Status Codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) wikipedia article. When using Postman, the response status code is described for easy reference.\n\nNote that if an invalid status code is requested to be sent, the server returns a status code of `400 Bad Request`.",
         "operationId": "responseStatusCode",
@@ -1478,7 +1508,9 @@
     },
     "/stream/5": {
       "get": {
-        "tags": ["Utilities"],
+        "tags": [
+          "Utilities"
+        ],
         "summary": "Streamed Response",
         "description": "This endpoint allows one to recieve streaming http response using [chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) of a configurable length.\n\nA streaming response does not wait for the entire response to be generated on server before flushing it out. This implies that for a fairly large response, parts of it can be streamed to the requestee as and when it is generated on server. The client can then take actions of processing this partially received data.",
         "operationId": "streamedResponse",
@@ -1491,7 +1523,9 @@
     },
     "/delay/2": {
       "get": {
-        "tags": ["Utilities"],
+        "tags": [
+          "Utilities"
+        ],
         "summary": "Delay Response",
         "description": "Using this endpoint one can configure how long it takes for the server to come back with a response. Appending a number to the URL defines the time (in seconds) the server will wait before responding.\n\nNote that a maximum delay of 10 seconds is accepted by the server.",
         "operationId": "delayResponse",
@@ -1562,7 +1596,9 @@
     },
     "/encoding/utf8": {
       "get": {
-        "tags": ["Utilities"],
+        "tags": [
+          "Utilities"
+        ],
         "summary": "Get UTF8 Encoded Response",
         "description": "If a response of an endpoint requires to send data beyond the basic English / ASCII character set, the `charset` parameter in the `Content-Type` response header defines the character encoding policy.\n\nThis endpoint returns an `UTF8` character encoded response body with text in various languages such as Greek, Latin, East Asian, etc. Postman can interpret the character encoding and use appropriate methods to display the character set in responses.",
         "operationId": "getUtf8EncodedResponse",
@@ -1575,7 +1611,9 @@
     },
     "/gzip": {
       "get": {
-        "tags": ["Utilities"],
+        "tags": [
+          "Utilities"
+        ],
         "summary": "GZip Compressed Response",
         "description": "This endpoint returns the response using [gzip compression algoritm](https://en.wikipedia.org/wiki/Gzip).\nThe uncompressed response is a JSON string containing the details of the request sent by the client. For this endpoint to work, one should request with `Accept-encoding` header containing `gzip` as part of its value. Postman supports gzip, deflate and SDCH decoding and automatically sends them as part of the request.\n\nHTTP Compression allows the server to send responses in a compressed format, which is uncompressed by the client before processing. This reduces network bandwidth consumption at the cost of increase in CPU usage.\nTo know more about this, refer the [HTTP Compression](https://en.wikipedia.org/wiki/HTTP_compression) wikipedia article.",
         "operationId": "gzipCompressedResponse",
@@ -1588,7 +1626,9 @@
     },
     "/deflate": {
       "get": {
-        "tags": ["Utilities"],
+        "tags": [
+          "Utilities"
+        ],
         "summary": "Deflate Compressed Response",
         "description": "This endpoint returns the response using [deflate compression algoritm](https://en.wikipedia.org/wiki/DEFLATE). \nThe uncompressed response is a JSON string containing the details of the request sent by the client. For this endpoint to work, one should request with `Accept-encoding` header containing `deflate` as part of its value. Postman supports gzip, deflate and SDCH decoding and automatically sends them as part of the request.\n\nHTTP Compression allows the server to send responses in a compressed format, which is uncompressed by the client before processing. This reduces network bandwidth consumption at the cost of increase in CPU usage.\nTo know more about this, refer the [HTTP Compression](https://en.wikipedia.org/wiki/HTTP_compression) wikipedia article.",
         "operationId": "deflateCompressedResponse",
@@ -1601,7 +1641,9 @@
     },
     "/ip": {
       "get": {
-        "tags": ["Utilities"],
+        "tags": [
+          "Utilities"
+        ],
         "summary": "IP address in JSON format",
         "description": "A simple `GET` request to return the IP address of the source request in the following `JSON` format:\n\n```json\n{\n  ip: \"request-ip-address\"\n}\n```",
         "operationId": "ipAddressInJsonFormat",
@@ -1614,7 +1656,9 @@
     },
     "/time/now": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Current UTC time",
         "description": "A simple `GET` request to `/time/now` to return the current timestamp as a UTC string.\n\n```\nFri, 04 Nov 2016 09:00:46 GMT\n```",
         "operationId": "currentUtcTime",
@@ -1684,9 +1728,11 @@
         }
       }
     },
-    "/time/valid": {
+    "/time/valid/?timestamp=2016-10-10": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Timestamp validity",
         "description": "A simple `GET` request to `/time/valid` to determine the validity of the timestamp, (current by default).\nThis endpoint accepts `timestamp`, `locale`, `format`, and `strict` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format, with a valid key to indicate the result. The response code is `200`.\n\n```\n{\n  valid: true/false\n}\n```",
         "operationId": "timestampValidity",
@@ -1776,9 +1822,11 @@
         }
       }
     },
-    "/time/format": {
+    "/time/format/?timestamp=2016-10-10&format=mm": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Format timestamp",
         "description": "A simple `GET` request to `/time/format` to convert the timestamp to any desired valid format.\n\nThis endpoint accepts `timestamp`, `locale`, `format`, and `strict` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format, with a `format` key to indicate the result. The response code is `200` for valid query parameters, and `400` otherwise.\n\n```\n{\n  format: \"formatted-timestamp\"\n}\n```",
         "operationId": "formatTimestamp",
@@ -1807,9 +1855,11 @@
         }
       }
     },
-    "/time/unit": {
+    "/time/unit/?timestamp=2016-10-10&unit=day": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Extract timestamp unit",
         "description": "A simple `GET` request to `/time/unit` to extract the specified timestamp unit (as provided in the `unit` query parameter). The default unit returned is the `year`.\n\nThis endpoint accepts `timestamp`, `locale`, `format`, and `strict` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format, with a `unit` key to indicate the result. The response code is `200` for valid query parameters, and `400` otherwise.\n\n```\n{\n  unit: \"extracted-timestamp-unit\"\n}\n```",
         "operationId": "extractTimestampUnit",
@@ -1838,9 +1888,11 @@
         }
       }
     },
-    "/time/add": {
+    "/time/add/?timestamp=2016-10-10&years=100": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Time addition",
         "description": "A simple `GET` request to `/time/add` to add units of time to the specified / current timestamp (as provided in the `years`, `months`, `days`, `hours`, `minutes`, `seconds`, and `milliseconds` query parameters).\n\nThis endpoint accepts `timestamp`, `locale`, `format`, and `strict` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format, with a `sum` key to indicate the result. The response code is `200` for valid query parameters, and `400` otherwise.\n\n```\n{\n  sum: \"sum of (provided / current) and provided timestamps\"\n}\n```",
         "operationId": "timeAddition",
@@ -1869,9 +1921,11 @@
         }
       }
     },
-    "/time/subtract": {
+    "/time/subtract/?timestamp=2016-10-10&years=50": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Time subtraction",
         "description": "A simple `GET` request to `/time/subtract` to subtract units of time from the specified / current timestamp (as provided in the `years`, `months`, `days`, `hours`, `minutes`, `seconds`, and `milliseconds` query parameters).\n\nThis endpoint accepts `timestamp`, `locale`, `format`, and `strict` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format, with a `difference` key to indicate the result. The response code is `200` for valid query parameters, and `400` otherwise.\n\n```\n{\n  difference: \"difference between (provided / current) and provided timestamps\"\n}\n```",
         "operationId": "timeSubtraction",
@@ -1900,9 +1954,11 @@
         }
       }
     },
-    "/time/start": {
+    "/time/start/?timestamp=2016-10-10&unit=month": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Start of time",
         "description": "A simple `GET` request to `/time/start` to return a relative timstamp in the past from the specified / current timestamp (as provided in the `unit` query parameter).\n\nFor instance, if the `unit` has been specified as `month`, the returned timestamp would indicate the beginning of the current month. Similar results are returned for other units of time, like: `years`, `months`, `days`, `hours`, `minutes`, `seconds`, and `milliseconds`\n\nThis endpoint accepts `timestamp`, `locale`, `format`, and `strict` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format, with a `start` key to indicate the result. The response code is `200` for valid query parameters, and `400` otherwise.\n\n```\n{\n  start: \"A timestamp from the past, depending on the `unit` specified\"\n}\n```",
         "operationId": "startOfTime",
@@ -1931,9 +1987,11 @@
         }
       }
     },
-    "/time/object": {
+    "/time/object/?timestamp=2016-10-10": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Object representation",
         "description": "A simple `GET` request to `/time/object` to return the current / provided timestamp as a JSON object.\n\nFor instance, if the `unit` has been specified as `month`, the returned timestamp would indicate the beginning of the current month. Similar results are returned for other units of time, like: `years`, `months`, `days`, `hours`, `minutes`, `seconds`, and `milliseconds`\n\nThis endpoint accepts `timestamp`, `locale`, `format`, and `strict` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format. The response code is `200` for valid query parameters, and `400` otherwise.\n\n```\n{\n  years: 2016,\n  months: 10,\n  days: 10,\n  hours: 23,\n  minutes: 34,\n  seconds: 20,\n  milliseconds: 980\n}\n```",
         "operationId": "objectRepresentation",
@@ -1954,9 +2012,11 @@
         }
       }
     },
-    "/time/before": {
+    "/time/before/?timestamp=2016-10-10&target=2017-10-10": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Before comparisons",
         "description": "A simple `GET` request to `/time/before` to check if the provided timestamps is before a comparison `target` (query parameter).\n\nThis endpoint accepts `timestamp`, `locale`, `format`, `strict`, and `target` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format, with a `before` key to indicate the result. The response code is `200` for valid query parameters, and `400` otherwise.\n\n```\n{\n  before: true/false\n}\n```",
         "operationId": "beforeComparisons",
@@ -1985,9 +2045,11 @@
         }
       }
     },
-    "/time/after": {
+    "/time/after/?timestamp=2016-10-10&target=2017-10-10": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "After comparisons",
         "description": "A simple `GET` request to `/time/after` to check if the provided timestamps is after a comparison `target` (query parameter).\n\nThis endpoint accepts `timestamp`, `locale`, `format`, `strict`, and `target` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format, with a `after` key to indicate the result. The response code is `200` for valid query parameters, and `400` otherwise.\n\n```\n{\n  after: true/false\n}\n```",
         "operationId": "afterComparisons",
@@ -2016,9 +2078,11 @@
         }
       }
     },
-    "/time/between": {
+    "/time/between/?timestamp=2016-10-10&start=2017-10-10&end=2019-10-10": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Between timestamps",
         "description": "A simple `GET` request to `/time/between` to check if the provided timestamp is between a range specified by the `start` and `end` query parameters. A resolution limit can also be specified by the `unit` query parameter.\n\nFor instance, for a resolution `unit` of `month`,\n`2016-10-05` does lie between `2016-11-02` and `2016-09-01`.\n\nThis endpoint also accepts `timestamp`, `locale`, `format`, `strict`, and `target` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format, with a `between` key to indicate the result. The response code is `200` for valid query parameters, and `400` otherwise.\n\n```\n{\n  between: true/false\n}\n```",
         "operationId": "betweenTimestamps",
@@ -2055,9 +2119,11 @@
         }
       }
     },
-    "/time/leap": {
+    "/time/leap/?timestamp=2016-10-10": {
       "get": {
-        "tags": ["Utilities / Date and Time"],
+        "tags": [
+          "Utilities / Date and Time"
+        ],
         "summary": "Leap year check",
         "description": "A simple `GET` request to `/time/leap` to check if the provided/current timestamp belongs to a leap year.\n\nThis endpoint also accepts `timestamp`, `locale`, `format`, `strict`, and `target` query parameters to construct the date time instance to check against.\n\nResponses are provided in JSON format, with a `leap` key to indicate the result. The response code is `200` for valid query parameters, and `400` otherwise.\n\n```\n{\n  leap: true/false\n}\n```",
         "operationId": "leapYearCheck",
@@ -2078,9 +2144,11 @@
         }
       }
     },
-    "/transform/collection": {
+    "/transform/collection/?from=1&to=2": {
       "post": {
-        "tags": ["Utilities / Postman Collection"],
+        "tags": [
+          "Utilities / Postman Collection"
+        ],
         "summary": "Transform collection from format v1 to v2",
         "description": "Transform collection from format v1 to v2",
         "operationId": "transformCollectionFromFormatV1ToV2",
@@ -2099,6 +2167,535 @@
             "schema": {
               "type": "string",
               "example": "2"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "example": "A sample collection to demonstrate collections as a set of related requests"
+                  },
+                  "folders": {
+                    "type": "array",
+                    "items": {},
+                    "example": []
+                  },
+                  "id": {
+                    "type": "string",
+                    "example": "7875be4b-917d-4aff-8cc4-5606c36bf418"
+                  },
+                  "name": {
+                    "type": "string",
+                    "example": "Sample Postman Collection"
+                  },
+                  "order": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "example": "4d9134be-e8bf-4693-9cd7-1c0fc66ae739"
+                    },
+                    "example": [
+                      "4d9134be-e8bf-4693-9cd7-1c0fc66ae739",
+                      "141ba274-cc50-4377-a59c-e080066f375e",
+                      "4511ca8b-0bc7-430f-b894-a7ec1036f322"
+                    ]
+                  },
+                  "requests": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "collectionId": {
+                          "type": "string",
+                          "example": "877b9dae-a50e-4152-9b89-870c37216f78"
+                        },
+                        "data": {
+                          "type": "array",
+                          "items": {},
+                          "example": []
+                        },
+                        "dataMode": {
+                          "type": "string",
+                          "example": "raw"
+                        },
+                        "headers": {
+                          "type": "string",
+                          "example": ""
+                        },
+                        "id": {
+                          "type": "string",
+                          "example": "4d9134be-e8bf-4693-9cd7-1c0fc66ae739"
+                        },
+                        "method": {
+                          "type": "string",
+                          "example": "GET"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "A simple GET request"
+                        },
+                        "preRequestScript": {
+                          "type": "string",
+                          "example": ""
+                        },
+                        "rawModeData": {
+                          "type": "string",
+                          "example": ""
+                        },
+                        "tests": {
+                          "type": "string",
+                          "example": "tests['response code is 200'] = (responseCode.code === 200);"
+                        },
+                        "url": {
+                          "type": "string",
+                          "example": "https://postman-echo.com/get?source=newman-sample-github-collection"
+                        }
+                      }
+                    },
+                    "example": [
+                      {
+                        "collectionId": "877b9dae-a50e-4152-9b89-870c37216f78",
+                        "data": [],
+                        "headers": "",
+                        "id": "4d9134be-e8bf-4693-9cd7-1c0fc66ae739",
+                        "method": "GET",
+                        "name": "A simple GET request",
+                        "preRequestScript": "",
+                        "rawModeData": "",
+                        "tests": "tests['response code is 200'] = (responseCode.code === 200);",
+                        "url": "https://postman-echo.com/get?source=newman-sample-github-collection"
+                      },
+                      {
+                        "collectionId": "877b9dae-a50e-4152-9b89-870c37216f78",
+                        "data": [],
+                        "dataMode": "raw",
+                        "headers": "Content-Type: text/plain",
+                        "id": "141ba274-cc50-4377-a59c-e080066f375e",
+                        "method": "POST",
+                        "name": "A simple POST request",
+                        "rawModeData": "Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...",
+                        "url": "https://postman-echo.com/post"
+                      },
+                      {
+                        "collectionId": "877b9dae-a50e-4152-9b89-870c37216f78",
+                        "data": [],
+                        "dataMode": "raw",
+                        "headers": "Content-Type: application/json",
+                        "id": "4511ca8b-0bc7-430f-b894-a7ec1036f322",
+                        "method": "POST",
+                        "name": "A simple POST request with JSON body",
+                        "rawModeData": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}",
+                        "url": "https://postman-echo.com/post"
+                      }
+                    ]
+                  }
+                }
+              },
+              "examples": {
+                "Transform collection from format v1 to v2": {
+                  "value": {
+                    "description": "A sample collection to demonstrate collections as a set of related requests",
+                    "folders": [],
+                    "id": "7875be4b-917d-4aff-8cc4-5606c36bf418",
+                    "name": "Sample Postman Collection",
+                    "order": [
+                      "4d9134be-e8bf-4693-9cd7-1c0fc66ae739",
+                      "141ba274-cc50-4377-a59c-e080066f375e",
+                      "4511ca8b-0bc7-430f-b894-a7ec1036f322"
+                    ],
+                    "requests": [
+                      {
+                        "collectionId": "877b9dae-a50e-4152-9b89-870c37216f78",
+                        "data": [],
+                        "headers": "",
+                        "id": "4d9134be-e8bf-4693-9cd7-1c0fc66ae739",
+                        "method": "GET",
+                        "name": "A simple GET request",
+                        "preRequestScript": "",
+                        "rawModeData": "",
+                        "tests": "tests['response code is 200'] = (responseCode.code === 200);",
+                        "url": "https://postman-echo.com/get?source=newman-sample-github-collection"
+                      },
+                      {
+                        "collectionId": "877b9dae-a50e-4152-9b89-870c37216f78",
+                        "data": [],
+                        "dataMode": "raw",
+                        "headers": "Content-Type: text/plain",
+                        "id": "141ba274-cc50-4377-a59c-e080066f375e",
+                        "method": "POST",
+                        "name": "A simple POST request",
+                        "rawModeData": "Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...",
+                        "url": "https://postman-echo.com/post"
+                      },
+                      {
+                        "collectionId": "877b9dae-a50e-4152-9b89-870c37216f78",
+                        "data": [],
+                        "dataMode": "raw",
+                        "headers": "Content-Type: application/json",
+                        "id": "4511ca8b-0bc7-430f-b894-a7ec1036f322",
+                        "method": "POST",
+                        "name": "A simple POST request with JSON body",
+                        "rawModeData": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}",
+                        "url": "https://postman-echo.com/post"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sample v2 Response",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "gzip"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Wed, 11 Jan 2017 10:41:32 GMT"
+                }
+              },
+              "ETag": {
+                "schema": {
+                  "type": "string",
+                  "example": "W/\"4cc-7P727Clhlrl9+b1/vneniw\""
+                }
+              },
+              "Server": {
+                "schema": {
+                  "type": "string",
+                  "example": "nginx/1.10.1"
+                }
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "X-HTTP-Method-Override, Accept-Encoding"
+                }
+              },
+              "set-cookie": {
+                "schema": {
+                  "type": "string",
+                  "example": "sails.sid=s%3AHtnQ1hlPxoj7wZahoNkcjN-aw9nQL0fc.KSyfLbEKhv1Lt3LvH13Ogjv9ENZgsBBSM6V8Y7TqVOU; Path=/; HttpOnly"
+                }
+              },
+              "transfer-encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "info": {
+                      "type": "object",
+                      "properties": {
+                        "_postman_id": {
+                          "type": "string",
+                          "example": "7875be4b-917d-4aff-8cc4-5606c36bf418"
+                        },
+                        "description": {
+                          "type": "string",
+                          "example": "A sample collection to demonstrate collections as a set of related requests"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Sample Postman Collection"
+                        },
+                        "schema": {
+                          "type": "string",
+                          "example": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+                        }
+                      }
+                    },
+                    "item": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "listen": {
+                                  "type": "string",
+                                  "example": "test"
+                                },
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "example": "tests['response code is 200'] = (responseCode.code === 200);"
+                                      },
+                                      "example": [
+                                        "tests['response code is 200'] = (responseCode.code === 200);"
+                                      ]
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "example": "text/javascript"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "example": [
+                              {
+                                "listen": "test",
+                                "script": {
+                                  "exec": [
+                                    "tests['response code is 200'] = (responseCode.code === 200);"
+                                  ],
+                                  "type": "text/javascript"
+                                }
+                              }
+                            ]
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "A simple GET request"
+                          },
+                          "request": {
+                            "type": "object",
+                            "properties": {
+                              "body": {
+                                "type": "object",
+                                "properties": {
+                                  "mode": {
+                                    "type": "string",
+                                    "example": "raw"
+                                  },
+                                  "raw": {
+                                    "type": "string",
+                                    "example": ""
+                                  }
+                                }
+                              },
+                              "header": {
+                                "type": "array",
+                                "items": {},
+                                "example": []
+                              },
+                              "method": {
+                                "type": "string",
+                                "example": "GET"
+                              },
+                              "url": {
+                                "type": "string",
+                                "example": "https://postman-echo.com/get?source=newman-sample-github-collection"
+                              }
+                            }
+                          },
+                          "response": {
+                            "type": "array",
+                            "items": {},
+                            "example": []
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "exec": [
+                                  "tests['response code is 200'] = (responseCode.code === 200);"
+                                ],
+                                "type": "text/javascript"
+                              }
+                            }
+                          ],
+                          "name": "A simple GET request",
+                          "request": {
+                            "body": {
+                              "mode": "raw",
+                              "raw": ""
+                            },
+                            "header": [],
+                            "method": "GET",
+                            "url": "https://postman-echo.com/get?source=newman-sample-github-collection"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "A simple POST request",
+                          "request": {
+                            "body": {
+                              "mode": "raw",
+                              "raw": "Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium..."
+                            },
+                            "header": [
+                              {
+                                "description": "",
+                                "key": "Content-Type",
+                                "value": "text/plain"
+                              }
+                            ],
+                            "method": "POST",
+                            "url": "https://postman-echo.com/post"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "A simple POST request with JSON body",
+                          "request": {
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}"
+                            },
+                            "header": [
+                              {
+                                "description": "",
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "method": "POST",
+                            "url": "https://postman-echo.com/post"
+                          },
+                          "response": []
+                        }
+                      ]
+                    },
+                    "variables": {
+                      "type": "array",
+                      "items": {},
+                      "example": []
+                    }
+                  }
+                },
+                "examples": {
+                  "Sample v2 Response": {
+                    "value": {
+                      "info": {
+                        "_postman_id": "7875be4b-917d-4aff-8cc4-5606c36bf418",
+                        "description": "A sample collection to demonstrate collections as a set of related requests",
+                        "name": "Sample Postman Collection",
+                        "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+                      },
+                      "item": [
+                        {
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "exec": [
+                                  "tests['response code is 200'] = (responseCode.code === 200);"
+                                ],
+                                "type": "text/javascript"
+                              }
+                            }
+                          ],
+                          "name": "A simple GET request",
+                          "request": {
+                            "body": {
+                              "mode": "raw",
+                              "raw": ""
+                            },
+                            "header": [],
+                            "method": "GET",
+                            "url": "https://postman-echo.com/get?source=newman-sample-github-collection"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "A simple POST request",
+                          "request": {
+                            "body": {
+                              "mode": "raw",
+                              "raw": "Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium..."
+                            },
+                            "header": [
+                              {
+                                "description": "",
+                                "key": "Content-Type",
+                                "value": "text/plain"
+                              }
+                            ],
+                            "method": "POST",
+                            "url": "https://postman-echo.com/post"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "A simple POST request with JSON body",
+                          "request": {
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}"
+                            },
+                            "header": [
+                              {
+                                "description": "",
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "method": "POST",
+                            "url": "https://postman-echo.com/post"
+                          },
+                          "response": []
+                        }
+                      ],
+                      "variables": []
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transform/collection/?from=2&to=1": {
+      "post": {
+        "tags": [
+          "Utilities / Postman Collection"
+        ],
+        "summary": "Transform collection from format v2 to v1",
+        "description": "Transform collection from format v2 to v1",
+        "operationId": "transformCollectionFromFormatV2ToV1",
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "example": "2"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "example": "1"
             }
           }
         ],
@@ -2284,55 +2881,6 @@
                 }
               },
               "examples": {
-                "Transform collection from format v1 to v2": {
-                  "value": {
-                    "description": "A sample collection to demonstrate collections as a set of related requests",
-                    "folders": [],
-                    "id": "7875be4b-917d-4aff-8cc4-5606c36bf418",
-                    "name": "Sample Postman Collection",
-                    "order": [
-                      "4d9134be-e8bf-4693-9cd7-1c0fc66ae739",
-                      "141ba274-cc50-4377-a59c-e080066f375e",
-                      "4511ca8b-0bc7-430f-b894-a7ec1036f322"
-                    ],
-                    "requests": [
-                      {
-                        "collectionId": "877b9dae-a50e-4152-9b89-870c37216f78",
-                        "data": [],
-                        "headers": "",
-                        "id": "4d9134be-e8bf-4693-9cd7-1c0fc66ae739",
-                        "method": "GET",
-                        "name": "A simple GET request",
-                        "preRequestScript": "",
-                        "rawModeData": "",
-                        "tests": "tests['response code is 200'] = (responseCode.code === 200);",
-                        "url": "https://postman-echo.com/get?source=newman-sample-github-collection"
-                      },
-                      {
-                        "collectionId": "877b9dae-a50e-4152-9b89-870c37216f78",
-                        "data": [],
-                        "dataMode": "raw",
-                        "headers": "Content-Type: text/plain",
-                        "id": "141ba274-cc50-4377-a59c-e080066f375e",
-                        "method": "POST",
-                        "name": "A simple POST request",
-                        "rawModeData": "Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...",
-                        "url": "https://postman-echo.com/post"
-                      },
-                      {
-                        "collectionId": "877b9dae-a50e-4152-9b89-870c37216f78",
-                        "data": [],
-                        "dataMode": "raw",
-                        "headers": "Content-Type: application/json",
-                        "id": "4511ca8b-0bc7-430f-b894-a7ec1036f322",
-                        "method": "POST",
-                        "name": "A simple POST request with JSON body",
-                        "rawModeData": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}",
-                        "url": "https://postman-echo.com/post"
-                      }
-                    ]
-                  }
-                },
                 "Transform collection from format v2 to v1": {
                   "value": {
                     "info": {
@@ -2402,7 +2950,7 @@
         },
         "responses": {
           "200": {
-            "description": "Sample v2 Response / Sample v1 Response",
+            "description": "Sample v1 Response",
             "headers": {
               "Connection": {
                 "schema": {
@@ -2470,181 +3018,6 @@
                     "id": {
                       "type": "string",
                       "example": "0c42230c-c8e4-4ca0-a4aa-d393971de8b8"
-                    },
-                    "info": {
-                      "type": "object",
-                      "properties": {
-                        "_postman_id": {
-                          "type": "string",
-                          "example": "7875be4b-917d-4aff-8cc4-5606c36bf418"
-                        },
-                        "description": {
-                          "type": "string",
-                          "example": "A sample collection to demonstrate collections as a set of related requests"
-                        },
-                        "name": {
-                          "type": "string",
-                          "example": "Sample Postman Collection"
-                        },
-                        "schema": {
-                          "type": "string",
-                          "example": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
-                        }
-                      }
-                    },
-                    "item": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "event": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "listen": {
-                                  "type": "string",
-                                  "example": "test"
-                                },
-                                "script": {
-                                  "type": "object",
-                                  "properties": {
-                                    "exec": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "string",
-                                        "example": "tests['response code is 200'] = (responseCode.code === 200);"
-                                      },
-                                      "example": [
-                                        "tests['response code is 200'] = (responseCode.code === 200);"
-                                      ]
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "example": "text/javascript"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "example": [
-                              {
-                                "listen": "test",
-                                "script": {
-                                  "exec": [
-                                    "tests['response code is 200'] = (responseCode.code === 200);"
-                                  ],
-                                  "type": "text/javascript"
-                                }
-                              }
-                            ]
-                          },
-                          "name": {
-                            "type": "string",
-                            "example": "A simple GET request"
-                          },
-                          "request": {
-                            "type": "object",
-                            "properties": {
-                              "body": {
-                                "type": "object",
-                                "properties": {
-                                  "mode": {
-                                    "type": "string",
-                                    "example": "raw"
-                                  },
-                                  "raw": {
-                                    "type": "string",
-                                    "example": ""
-                                  }
-                                }
-                              },
-                              "header": {
-                                "type": "array",
-                                "items": {},
-                                "example": []
-                              },
-                              "method": {
-                                "type": "string",
-                                "example": "GET"
-                              },
-                              "url": {
-                                "type": "string",
-                                "example": "https://postman-echo.com/get?source=newman-sample-github-collection"
-                              }
-                            }
-                          },
-                          "response": {
-                            "type": "array",
-                            "items": {},
-                            "example": []
-                          }
-                        }
-                      },
-                      "example": [
-                        {
-                          "event": [
-                            {
-                              "listen": "test",
-                              "script": {
-                                "exec": [
-                                  "tests['response code is 200'] = (responseCode.code === 200);"
-                                ],
-                                "type": "text/javascript"
-                              }
-                            }
-                          ],
-                          "name": "A simple GET request",
-                          "request": {
-                            "body": {
-                              "mode": "raw",
-                              "raw": ""
-                            },
-                            "header": [],
-                            "method": "GET",
-                            "url": "https://postman-echo.com/get?source=newman-sample-github-collection"
-                          },
-                          "response": []
-                        },
-                        {
-                          "name": "A simple POST request",
-                          "request": {
-                            "body": {
-                              "mode": "raw",
-                              "raw": "Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium..."
-                            },
-                            "header": [
-                              {
-                                "description": "",
-                                "key": "Content-Type",
-                                "value": "text/plain"
-                              }
-                            ],
-                            "method": "POST",
-                            "url": "https://postman-echo.com/post"
-                          },
-                          "response": []
-                        },
-                        {
-                          "name": "A simple POST request with JSON body",
-                          "request": {
-                            "body": {
-                              "mode": "raw",
-                              "raw": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}"
-                            },
-                            "header": [
-                              {
-                                "description": "",
-                                "key": "Content-Type",
-                                "value": "application/json"
-                              }
-                            ],
-                            "method": "POST",
-                            "url": "https://postman-echo.com/post"
-                          },
-                          "response": []
-                        }
-                      ]
                     },
                     "name": {
                       "type": "string",
@@ -2750,11 +3123,6 @@
                           "url": "https://postman-echo.com/post"
                         }
                       ]
-                    },
-                    "variables": {
-                      "type": "array",
-                      "items": {},
-                      "example": []
                     }
                   }
                 },
@@ -2807,81 +3175,6 @@
                         }
                       ]
                     }
-                  },
-                  "Sample v2 Response": {
-                    "value": {
-                      "info": {
-                        "_postman_id": "7875be4b-917d-4aff-8cc4-5606c36bf418",
-                        "description": "A sample collection to demonstrate collections as a set of related requests",
-                        "name": "Sample Postman Collection",
-                        "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
-                      },
-                      "item": [
-                        {
-                          "event": [
-                            {
-                              "listen": "test",
-                              "script": {
-                                "exec": [
-                                  "tests['response code is 200'] = (responseCode.code === 200);"
-                                ],
-                                "type": "text/javascript"
-                              }
-                            }
-                          ],
-                          "name": "A simple GET request",
-                          "request": {
-                            "body": {
-                              "mode": "raw",
-                              "raw": ""
-                            },
-                            "header": [],
-                            "method": "GET",
-                            "url": "https://postman-echo.com/get?source=newman-sample-github-collection"
-                          },
-                          "response": []
-                        },
-                        {
-                          "name": "A simple POST request",
-                          "request": {
-                            "body": {
-                              "mode": "raw",
-                              "raw": "Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium..."
-                            },
-                            "header": [
-                              {
-                                "description": "",
-                                "key": "Content-Type",
-                                "value": "text/plain"
-                              }
-                            ],
-                            "method": "POST",
-                            "url": "https://postman-echo.com/post"
-                          },
-                          "response": []
-                        },
-                        {
-                          "name": "A simple POST request with JSON body",
-                          "request": {
-                            "body": {
-                              "mode": "raw",
-                              "raw": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}"
-                            },
-                            "header": [
-                              {
-                                "description": "",
-                                "key": "Content-Type",
-                                "value": "application/json"
-                              }
-                            ],
-                            "method": "POST",
-                            "url": "https://postman-echo.com/post"
-                          },
-                          "response": []
-                        }
-                      ],
-                      "variables": []
-                    }
                   }
                 }
               }
@@ -2892,7 +3185,9 @@
     },
     "/{method}/hello": {
       "get": {
-        "tags": ["Custom"],
+        "tags": [
+          "Custom"
+        ],
         "summary": "Path variables",
         "description": "Path variables",
         "operationId": "pathVariables",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,14 +1,35 @@
+use std::fs::File;
+use std::io::prelude::*;
+
+
 macro_rules! test_fixture {
     ($name:ident, $filename:expr) => {
         #[test]
         fn $name() {
             let filename = get_fixture($filename);
-            let options = postman2openapi::TranspileOptions {
-                format: postman2openapi::TargetFormat::Json,
-            };
+                let options = postman2openapi::TranspileOptions {
+                    format: postman2openapi::TargetFormat::Json,
+                };
             match postman2openapi::from_path(&filename, options) {
-                Ok(_oas) => assert!(true),
-                Err(err) => assert!(false, "{:?}", err),
+                Ok(_oas) => {
+                   // Specify the target file path convert filename to filename_oas.json
+                   let file_path = filename.replace("postman.json", "oas.json");
+
+                    // Remove file if it exists
+                    std::fs::remove_file(file_path.clone()).unwrap_or_default();
+
+                    // Open or create the file
+                    let mut file = File::create(file_path).expect("Failed to create file");
+
+                    // Write data to the file
+                    match file.write_all(_oas.as_bytes()) {
+                        Ok(_) => assert!(true),
+                        Err(err) => assert!(false, "{:?}", err),
+                    }
+                },
+                Err(err) => {
+                    assert!(false, "{:?}", err);
+                },
             }
         }
     };

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,19 +1,18 @@
 use std::fs::File;
 use std::io::prelude::*;
 
-
 macro_rules! test_fixture {
     ($name:ident, $filename:expr) => {
         #[test]
         fn $name() {
             let filename = get_fixture($filename);
-                let options = postman2openapi::TranspileOptions {
-                    format: postman2openapi::TargetFormat::Json,
-                };
+            let options = postman2openapi::TranspileOptions {
+                format: postman2openapi::TargetFormat::Json,
+            };
             match postman2openapi::from_path(&filename, options) {
                 Ok(_oas) => {
-                   // Specify the target file path convert filename to filename_oas.json
-                   let file_path = filename.replace("postman.json", "oas.json");
+                    // Specify the target file path convert filename to filename_oas.json
+                    let file_path = filename.replace("postman.json", "oas.json");
 
                     // Remove file if it exists
                     std::fs::remove_file(file_path.clone()).unwrap_or_default();
@@ -26,10 +25,10 @@ macro_rules! test_fixture {
                         Ok(_) => assert!(true),
                         Err(err) => assert!(false, "{:?}", err),
                     }
-                },
+                }
                 Err(err) => {
                     assert!(false, "{:?}", err);
-                },
+                }
             }
         }
     };


### PR DESCRIPTION
Address #77. I've tested with collection I showed in #77
<img width="783" alt="image" src="https://github.com/kevinswiber/postman2openapi/assets/30227910/3a352ba9-f1db-4422-8003-010010770bda">

And here is current test source `twitter-api`
<img width="1330" alt="image" src="https://github.com/kevinswiber/postman2openapi/assets/30227910/a8818746-be0c-47b6-ab34-a17d3e21baa1">


This PR attempts to append a 'query parameter' inside 'paths' and then concatenate to generate the segment.